### PR TITLE
Update "Randomize Backgrounds" option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -408,6 +408,3 @@ FodyWeavers.xsd
 
 ### VisualStudio Patch ###
 # Additional files built by Visual Studio
-
-# End of https://www.toptal.com/developers/gitignore/api/visualstudio
-/Randomize.cs

--- a/.gitignore
+++ b/.gitignore
@@ -408,3 +408,5 @@ FodyWeavers.xsd
 
 ### VisualStudio Patch ###
 # Additional files built by Visual Studio
+
+# End of https://www.toptal.com/developers/gitignore/api/visualstudio

--- a/.gitignore
+++ b/.gitignore
@@ -410,3 +410,4 @@ FodyWeavers.xsd
 # Additional files built by Visual Studio
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudio
+/Randomize.cs

--- a/Randomize.cs
+++ b/Randomize.cs
@@ -2124,16 +2124,40 @@ namespace MLSSRandomizerForm
 
         public void BackgroundRandomize()
         {
-            if (Form1.background)
-            {
-                var location = Enumerable.Range(0, 0x4740).ToList();
-                location.RemoveAll(x => x != (x / 0x20) * 0x20);
+            var location = Enumerable.Range(0, 0x1741).ToList();
+            location.RemoveAll(x => x != (x / 0x20) * 0x20);
 
-                foreach (int address in location)
+            foreach (int address in location)
+            {
+                stream.Seek(address + 0x50300C + 8, SeekOrigin.Begin);
+                int enemy = stream.ReadByte();
+
+                if ((enemy == 0x9B) || (enemy == 0x9E)) // Checks enemies with wave attack (Morton, Roy) (note: double check Wiggler)
+                {
+                    stream.Seek(address + 0x50300C + 3, SeekOrigin.Begin);
+                    if (Form1.background)
+                    {
+                        int[] wavey_backgrounds = { 0x02, 0x03, 0x05, 0x06, 0x0D, 0x22, 0x23, 0x24, 0x26 }; // Wave-acceptable backgrounds
+                        stream.WriteByte((byte)wavey_backgrounds[random.Next(wavey_backgrounds.Length)]);
+                    }
+                    else
+                    {
+                        if (enemy == 0x9B)
+                        {
+                            stream.WriteByte((byte)0x24);
+                        }
+                        else
+                        {
+                            stream.WriteByte((byte)0x23);
+                        }
+                    }
+                }
+                else if(Form1.background)
                 {
                     stream.Seek(address + 0x50300C + 3, SeekOrigin.Begin);
                     stream.WriteByte((byte)random.Next(0, 0x27));
                 }
+
             }
         }
 

--- a/Randomize.cs
+++ b/Randomize.cs
@@ -2126,12 +2126,12 @@ namespace MLSSRandomizerForm
         {
             if (Form1.background)
             {
-                string[] location = StreamInitialize(Environment.CurrentDirectory + "/items/Enemies/Encounters.txt");
-                string[] boss = StreamInitialize(Environment.CurrentDirectory + "/items/Enemies/BossEncounters.txt");
-                location = location.Concat(boss).ToArray();
-                foreach (string str in location)
+                var location = Enumerable.Range(0, 0x4740).ToList();
+                location.RemoveAll(x => x != (x / 0x20) * 0x20);
+
+                foreach (int address in location)
                 {
-                    stream.Seek(Convert.ToUInt32(str, 16) + 3, SeekOrigin.Begin);
+                    stream.Seek(address + 0x50300C + 3, SeekOrigin.Begin);
                     stream.WriteByte((byte)random.Next(0, 0x27));
                 }
             }

--- a/Randomize.cs
+++ b/Randomize.cs
@@ -2132,7 +2132,7 @@ namespace MLSSRandomizerForm
                 stream.Seek(address + 0x50300C + 8, SeekOrigin.Begin);
                 int enemy = stream.ReadByte();
 
-                if ((enemy == 0x9B) || (enemy == 0x9E)) // Checks enemies with wave attack (Morton, Roy) (note: double check Wiggler)
+                if ((enemy == 0x9B) || (enemy == 0x9E)) // Checks enemies with wave attack (Morton, Roy)
                 {
                     stream.Seek(address + 0x50300C + 3, SeekOrigin.Begin);
                     if (Form1.background)
@@ -2140,19 +2140,29 @@ namespace MLSSRandomizerForm
                         int[] wavey_backgrounds = { 0x02, 0x03, 0x05, 0x06, 0x0D, 0x22, 0x23, 0x24, 0x26 }; // Wave-acceptable backgrounds
                         stream.WriteByte((byte)wavey_backgrounds[random.Next(wavey_backgrounds.Length)]);
                     }
+                    else if (enemy == 0x9B)
+                    {
+                        stream.WriteByte((byte)0x24);
+                    }
                     else
                     {
-                        if (enemy == 0x9B)
-                        {
-                            stream.WriteByte((byte)0x24);
-                        }
-                        else
-                        {
-                            stream.WriteByte((byte)0x23);
-                        }
+                        stream.WriteByte((byte)0x23);
                     }
                 }
-                else if(Form1.background)
+                else if (enemy == 0x70) // Wiggler has different waves
+                {
+                    stream.Seek(address + 0x50300C + 3, SeekOrigin.Begin);
+                    if (Form1.background)
+                    {
+                        int[] wavey_backgrounds = { 0x01, 0x03, 0x05, 0x06, 0x07, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x20, 0x21, 0x23, 0x24, 0x25, 0x26, 0x27 };
+                        stream.WriteByte((byte)wavey_backgrounds[random.Next(wavey_backgrounds.Length)]);
+                    }
+                    else
+                    {
+                        stream.WriteByte((byte)0x0F);
+                    }
+                }
+                else if (Form1.background)
                 {
                     stream.Seek(address + 0x50300C + 3, SeekOrigin.Begin);
                     stream.WriteByte((byte)random.Next(0, 0x27));


### PR DESCRIPTION
- If option is enabled, every single fight's background is now randomized (including Queen Bean, Chuckolator, Cackletta's Soul, ...) instead of just most of them
- If option is enabled, selectively randomize backgrounds for Wiggler, Morton and Roy so they only have backgrounds that show the shockwaves, making the attack dodge-able
- If option is disabled, **forces** backgrounds for Wiggler, Morton and Roy to be their vanilla background, even if enemies are randomized and you find them in a different spot. This ensures waves remain visible.